### PR TITLE
Fixes proprocessState bug.

### DIFF
--- a/resumable.js
+++ b/resumable.js
@@ -647,7 +647,7 @@
         var preprocess = $.getOpt('preprocess');
         if(typeof preprocess === 'function') {
           switch($.preprocessState) {
-          case 0: preprocess($); $.preprocessState = 1; return;
+          case 0: $.preprocessState = 1; preprocess($); return;
           case 1: return;
           case 2: break;
           }


### PR DESCRIPTION
This bug causes the preprocessState to be reset to 1 even after preprocess runs and sets it to 2. This results in chunks not thinking they are complete and causing issues later in the event chain.

The issue is found in issue #114, which was marked as closed, but the code was never merged.